### PR TITLE
feat: add github action config for pushing container image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,9 @@ jobs:
           with:
             submodules: true
         -
+          name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
+        -
           name: Login to DockerHub
           uses: docker/login-action@v1 
           with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,19 @@ jobs:
         - uses: actions/checkout@v2
           with:
             submodules: true
+        - name: Get current date
+          id: date
+          run: echo "::set-output name=date::$(date --utc +%Y%m%d.%H%M)"
         -
           run: |
+            timestamp=$(date --utc +%Y%m%d.%H%M)
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
-            docker build --no-cache -t $GITHUB_REPOSITORY:latest .
+            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA:0:8}-${timestamp} .
             docker push --all-tags $GITHUB_REPOSITORY
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            SHORT_SHA: ${GITHUB_SHA:0:8}
+            BRANCH: "${GITHUB_REF/refs\/heads\//}"
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           uses: docker/build-push-action@v2
           with:
             push: true
-            tags: $GITHUB_REPOSITORY:latest,$GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
+            tags: ${GITHUB_REPOSITORY}:latest,${GITHUB_REPOSITORY}:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
         -
           name: Image digest
           run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,26 +9,35 @@ on:
     tags:
       - '*'
 
-env:
-  IMAGE_TAG: ${{ github.sha }}
-
 jobs:
   build-and-push:
       runs-on: ubuntu-18.04
       if: github.ref == 'refs/heads/master'
       steps:
+        - run: |
+          echo "CURRENT_DATE_TIME=$(date --utc +%Y%m%d.%H%M)" >> $GITHUB_ENV
+        - run: |
+          echo "SHORT_SHA=$(GITHUB_SHA:0:8)" >> $GITHUB_ENV
+        - run: |
+          echo "SHORT_SHA=${GITHUB_REF/refs\/heads\//} >> $GITHUB_ENV
         - uses: actions/checkout@v2
           with:
             submodules: true
-        - name: build & push
-          run: |
-            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-            docker build --no-cache -t $DOCKER_USERNAME/$REPO_NAME:latest .
-            docker push $DOCKER_USERNAME/$REPO_NAME:latest
-            .scripts/github/retag-and-push.sh $REPO_NAME latest
-          env:
-            REPO_NAME: ${{ github.event.repository.name }}
-            DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      #   -
+      #     name: Login to DockerHub
+      #     uses: docker/login-action@v1 
+      #     with:
+      #       username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #       password: ${{ secrets.DOCKERHUB_TOKEN }}
+      #   -
+      #     name: Build and push
+      #     id: docker_build
+      #     uses: docker/build-push-action@v2
+      #     with:
+      #       push: true
+      #       tags: $GITHUB_REPOSITORY:latest, $GITHUB_REPOSITORY:
+      # -
+      #   name: Image digest
+      #   run: echo ${{ steps.docker_build.outputs.digest }}
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,9 @@ jobs:
           uses: docker/build-push-action@v2
           with:
             push: true
-            tags: $GITHUB_REPOSITORY:latest, $GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
-      -
-        name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+            tags: $GITHUB_REPOSITORY:latest,$GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
+        -
+          name: Image digest
+          run: echo ${{ steps.docker_build.outputs.digest }}
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,8 @@ jobs:
         - name: Create variables
           run: |
             echo "CURRENT_DATE_TIME=$(date --utc +%Y%m%d.%H%M)" >> $GITHUB_ENV
-            echo "SHORT_SHA=$(GITHUB_SHA:0:8)" >> $GITHUB_ENV
-            echo "SHORT_SHA=${GITHUB_REF/refs\/heads\//} >> $GITHUB_ENV
+            echo "BRANCH=$(GITHUB_REF/refs\/heads\//) >> $GITHUB_ENV
+            echo "SHORT_SHA=$(GITHUB_SHA::8) >> $GITHUB_ENV
         - uses: actions/checkout@v2
           with:
             submodules: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-push:
       runs-on: ubuntu-18.04
-      # if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
       steps:
         - uses: actions/checkout@v2
           with:
@@ -23,8 +23,9 @@ jobs:
         -
           run: |
             timestamp=$(date --utc +%Y%m%d.%H%M)
+            branch="${GITHUB_REF/refs\/heads\//}"
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
-            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:master-${GITHUB_SHA:0:8}-${timestamp} .
+            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${branch}-${GITHUB_SHA:0:8}-${timestamp} .
             docker push --all-tags $GITHUB_REPOSITORY
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,5 +29,3 @@ jobs:
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,20 +18,12 @@ jobs:
           with:
             submodules: true
         -
-          name: Login to DockerHub
-          uses: docker/login-action@v1 
-          with:
-            username: ${{ secrets.DOCKERHUB_USERNAME }}
-            password: ${{ secrets.DOCKERHUB_TOKEN }}
-        -
-          name: Build and push
-          id: docker_build
-          uses: docker/build-push-action@v2
-          with:
-            push: true
-            tags: $GITHUB_REPOSITORY:latest,$GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
-        -
-          name: Image digest
-          run: echo ${{ steps.docker_build.outputs.digest }}
+          run: |
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
+            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA:0:8}-${date --utc +%Y%m%d.%H%M} .
+            docker push --all-tags $GITHUB_REPOSITORY
+          env:
+            DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,30 +13,24 @@ jobs:
   build-and-push:
       runs-on: ubuntu-18.04
       # if: github.ref == 'refs/heads/master'
-      steps:
-        - name: Create variables
-          run: |
-            echo "CURRENT_DATE_TIME=$(date --utc +%Y%m%d.%H%M)" >> $GITHUB_ENV
-            echo "BRANCH=$(GITHUB_REF/refs\/heads\//) >> $GITHUB_ENV
-            echo "SHORT_SHA=$(GITHUB_SHA::8) >> $GITHUB_ENV
         - uses: actions/checkout@v2
           with:
             submodules: true
-      #   -
-      #     name: Login to DockerHub
-      #     uses: docker/login-action@v1 
-      #     with:
-      #       username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #       password: ${{ secrets.DOCKERHUB_TOKEN }}
-      #   -
-      #     name: Build and push
-      #     id: docker_build
-      #     uses: docker/build-push-action@v2
-      #     with:
-      #       push: true
-      #       tags: $GITHUB_REPOSITORY:latest, $GITHUB_REPOSITORY:
-      # -
-      #   name: Image digest
-      #   run: echo ${{ steps.docker_build.outputs.digest }}
+        -
+          name: Login to DockerHub
+          uses: docker/login-action@v1 
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+        -
+          name: Build and push
+          id: docker_build
+          uses: docker/build-push-action@v2
+          with:
+            push: true
+            tags: $GITHUB_REPOSITORY:latest, $GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,5 @@ jobs:
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-            SHORT_SHA: ${GITHUB_SHA:0:8}
-            BRANCH: "${GITHUB_REF/refs\/heads\//}"
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,9 @@ jobs:
         -
           run: |
             timestamp=$(date --utc +%Y%m%d.%H%M)
+            branch="${GITHUB_REF/refs\/heads\//}"
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
-            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA:0:8}-${timestamp} .
+            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${branch}-${GITHUB_SHA:0:8}-${timestamp} .
             docker push --all-tags $GITHUB_REPOSITORY
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-and-push:
       runs-on: ubuntu-18.04
-      if: github.ref == 'refs/heads/master'
+      # if: github.ref == 'refs/heads/master'
       steps:
         - name: Create variables
           run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         -
           run: |
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
-            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA:0:8}-${date --utc +%Y%m%d.%H%M} .
+            docker build --no-cache -t $GITHUB_REPOSITORY:latest .
             docker push --all-tags $GITHUB_REPOSITORY
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+name: Pipeline
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+env:
+  IMAGE_TAG: ${{ github.sha }}
+
+jobs:
+  build-and-push:
+      runs-on: ubuntu-18.04
+      if: github.ref == 'refs/heads/master'
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            submodules: true
+        - name: build & push
+          run: |
+            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+            docker build --no-cache -t $DOCKER_USERNAME/$REPO_NAME:latest .
+            docker push $DOCKER_USERNAME/$REPO_NAME:latest
+            .scripts/github/retag-and-push.sh $REPO_NAME latest
+          env:
+            REPO_NAME: ${{ github.event.repository.name }}
+            DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,11 @@ jobs:
       runs-on: ubuntu-18.04
       if: github.ref == 'refs/heads/master'
       steps:
-        - run: |
-          echo "CURRENT_DATE_TIME=$(date --utc +%Y%m%d.%H%M)" >> $GITHUB_ENV
-        - run: |
-          echo "SHORT_SHA=$(GITHUB_SHA:0:8)" >> $GITHUB_ENV
-        - run: |
-          echo "SHORT_SHA=${GITHUB_REF/refs\/heads\//} >> $GITHUB_ENV
+        - name: Create variables
+          run: |
+            echo "CURRENT_DATE_TIME=$(date --utc +%Y%m%d.%H%M)" >> $GITHUB_ENV
+            echo "SHORT_SHA=$(GITHUB_SHA:0:8)" >> $GITHUB_ENV
+            echo "SHORT_SHA=${GITHUB_REF/refs\/heads\//} >> $GITHUB_ENV
         - uses: actions/checkout@v2
           with:
             submodules: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
   build-and-push:
       runs-on: ubuntu-18.04
       # if: github.ref == 'refs/heads/master'
+      steps:
         - uses: actions/checkout@v2
           with:
             submodules: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,8 @@ jobs:
         -
           run: |
             timestamp=$(date --utc +%Y%m%d.%H%M)
-            branch="${GITHUB_REF/refs\/heads\//}"
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_TOKEN
-            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:${branch}-${GITHUB_SHA:0:8}-${timestamp} .
+            docker build --no-cache -t $GITHUB_REPOSITORY:latest -t $GITHUB_REPOSITORY:master-${GITHUB_SHA:0:8}-${timestamp} .
             docker push --all-tags $GITHUB_REPOSITORY
           env:
             DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,6 @@ jobs:
           with:
             submodules: true
         -
-          name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v1
-        -
           name: Login to DockerHub
           uses: docker/login-action@v1 
           with:
@@ -32,7 +29,7 @@ jobs:
           uses: docker/build-push-action@v2
           with:
             push: true
-            tags: ${GITHUB_REPOSITORY}:latest,${GITHUB_REPOSITORY}:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
+            tags: $GITHUB_REPOSITORY:latest,$GITHUB_REPOSITORY:${GITHUB_REF/refs\/heads\//}-${GITHUB_SHA::8}-${date --utc +%Y%m%d.%H%M}
         -
           name: Image digest
           run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".scripts"]
+	path = .scripts
+	url = git@github.com:libero/scripts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".scripts"]
-	path = .scripts
-	url = git@github.com:libero/scripts.git


### PR DESCRIPTION
This action should run on merge to master pushing a `latest` tag of the container image. The libero script should internally deploy a `${branch}-${short-hash}` and  `${branch}-${short-hash}-${timestamp}` tag as well.

TODO before this gets merged -

- [ ] add github secrets for DOCKER_USERNAME & DOCKER_PASSWORD